### PR TITLE
Build file fixed to overwrite plugin in plugins folder

### DIFF
--- a/plugin/build.bat
+++ b/plugin/build.bat
@@ -1,1 +1,1 @@
-mvn install -f "pom.xml" & move /y "target\opensourcery-beta.jar" "..\server\plugins"
+mvn install -f "pom.xml" & robocopy "target" "..\server\plugins" "opensourcery-beta.jar" /is


### PR DESCRIPTION
Switched to robocopy which is able to overwrite the jar and allow for hot-reloading of plugins